### PR TITLE
Implement Mandelbrot in color

### DIFF
--- a/components/LoadLFortran.js
+++ b/components/LoadLFortran.js
@@ -82,6 +82,24 @@ function define_imports(memory, outputBuffer, exit_code, stdout_print) {
         outputBuffer.push(`<img alt="constructed image" src="${canvas.toDataURL('image/jpeg')}" height="${rows}" width="${cols}" style="aspect-ratio: 1 / 1;"/>`)
         flushBuffer();
     }
+    const show_image_color = (rows, cols, arr) => {
+        var arr2D_data = new DataView(memory.buffer, arr, Int32Array.BYTES_PER_ELEMENT * 4 * rows * cols);
+        var canvas = document.createElement("CANVAS");
+        canvas.width = cols;
+        canvas.height = rows;
+        var ctx = canvas.getContext("2d");
+        var imgData = ctx.createImageData(cols, rows);
+        // The data in DataView is stored as i32 per channel, while it
+        // should be i8. Currently we have to copy the i32 integer and assign
+        // it to the canvas' i8 integer. We have to index it with 4*i, because
+        // the getInt32 method accepts a byte index.
+        for (var i = 0; i < imgData.data.length; i++) {
+            imgData.data[i] = arr2D_data.getInt32(4*i, true);
+        }
+        ctx.putImageData(imgData, 0, 0);
+        outputBuffer.push(`<img alt="constructed image" src="${canvas.toDataURL('image/jpeg')}" height="${rows}" width="${cols}" style="aspect-ratio: 1 / 1;"/>`)
+        flushBuffer();
+    }
     var imports = {
         js: {
             memory: memory,
@@ -93,7 +111,8 @@ function define_imports(memory, outputBuffer, exit_code, stdout_print) {
             print_str: printStr,
             flush_buf: flushBuffer,
             set_exit_code: set_exit_code,
-            show_img: show_image
+            show_img: show_image,
+            show_img_color: show_image_color
         },
     };
     return imports;

--- a/utils/source_code_examples.js
+++ b/utils/source_code_examples.js
@@ -1,77 +1,55 @@
 var src_code_mandel_brot = `program mandelbrot
-    implicit none
-    integer  , parameter :: rk       = 8
-    integer  , parameter :: i_max    =  600
-    integer  , parameter :: j_max    =  450
-    integer  , parameter :: n_max    =  255
-    real (rk), parameter :: x_centre = -0.5_rk
-    real (rk), parameter :: y_centre =  0.0_rk
-    real (rk), parameter :: width    =  4.0_rk
-    real (rk), parameter :: height   =  3.0_rk
-    real (rk), parameter :: dx_di    =   width / i_max
-    real (rk), parameter :: dy_dj    = -height / j_max
-    real (rk), parameter :: x_offset = x_centre - 0.5_rk * (i_max + 1) * dx_di
-    real (rk), parameter :: y_offset = y_centre - 0.5_rk * (j_max + 1) * dy_dj
-    integer :: image(j_max, i_max), image_color(j_max, i_max, 4), palette(4,3)
-    integer   :: i, idx
-    integer   :: j
-    integer   :: n
-    real (rk) :: x
-    real (rk) :: y
-    real (rk) :: x_0
-    real (rk) :: y_0
-    real (rk) :: x_sqr
-    real (rk) :: y_sqr
-    interface
-        subroutine show_img(n, m, A) bind(c)
-        integer, intent(in) :: n, m
-        integer, intent(in) :: A(n,m)
-        end subroutine
-
-        subroutine show_img_color(n, m, A) bind(c)
-        integer, intent(in) :: n, m
-        integer, intent(in) :: A(n,m,4)
-        end subroutine
-    end interface
-    do j = 1, j_max
-        y_0 = y_offset + dy_dj * j
-        do i = 1, i_max
-            x_0 = x_offset + dx_di * i
-            x = 0.0_rk
-            y = 0.0_rk
-            n = 0
-            do
-                x_sqr = x ** 2
-                y_sqr = y ** 2
-                if (x_sqr + y_sqr > 4.0_rk .or. n == n_max) then
-                    image(j,i) = 255-n
-                    exit
-                end if
-                y = y_0 + 2.0_rk * x * y
-                x = x_0 + x_sqr - y_sqr
-                n = n + 1
-            end do
+integer, parameter :: Nx = 600, Ny = 450, n_max = 255, dp=8
+real(dp), parameter :: xcenter = -0.5_dp, ycenter = 0.0_dp, &
+    width = 4, height = 3, dx_di = width/Nx, dy_dj = -height/Ny, &
+    x_offset = xcenter - (Nx+1)*dx_di/2, y_offset = ycenter - (Ny+1)*dy_dj/2
+integer :: image(Ny,Nx), image_color(Ny,Nx,4), palette(4,3), i, j, n, idx
+real(dp) :: x, y, x_0, y_0, x_sqr, y_sqr
+interface
+    subroutine show_img(n, m, A) bind(c)
+    integer, intent(in) :: n, m
+    integer, intent(in) :: A(n,m)
+    end subroutine
+    subroutine show_img_color(n, m, A) bind(c)
+    integer, intent(in) :: n, m
+    integer, intent(in) :: A(n,m,4)
+    end subroutine
+end interface
+do j = 1, Ny
+    y_0 = y_offset + dy_dj * j
+    do i = 1, Nx
+        x_0 = x_offset + dx_di * i
+        x = 0; y = 0; n = 0
+        do
+            x_sqr = x ** 2; y_sqr = y ** 2
+            if (x_sqr + y_sqr > 4 .or. n == n_max) then
+                image(j,i) = 255-n
+                exit
+            end if
+            y = y_0 + 2 * x * y
+            x = x_0 + x_sqr - y_sqr
+            n = n + 1
         end do
     end do
-    palette(1,1) =   0; palette(1,2) = 135; palette(1,3) =  68
-    palette(2,1) =   0; palette(2,2) =  87; palette(2,3) = 231
-    palette(3,1) = 214; palette(3,2) =  45; palette(3,3) =  32
-    palette(4,1) = 255; palette(4,2) = 167; palette(4,3) =   0
-
-    do j = 1, j_max
-        do i = 1, i_max
-            idx = image(j,i) - (image(j,i)/4)*4 + 1
-            image_color(j,i,1) = palette(idx,1) ! Red
-            image_color(j,i,2) = palette(idx,2) ! Green
-            image_color(j,i,3) = palette(idx,3) ! Blue
-            image_color(j,i,4) = 255            ! Alpha
-        end do
+end do
+palette(1,1) =   0; palette(1,2) = 135; palette(1,3) =  68
+palette(2,1) =   0; palette(2,2) =  87; palette(2,3) = 231
+palette(3,1) = 214; palette(3,2) =  45; palette(3,3) =  32
+palette(4,1) = 255; palette(4,2) = 167; palette(4,3) =   0
+do j = 1, Ny
+    do i = 1, Nx
+        idx = image(j,i) - (image(j,i)/4)*4 + 1
+        image_color(j,i,1) = palette(idx,1) ! Red
+        image_color(j,i,2) = palette(idx,2) ! Green
+        image_color(j,i,3) = palette(idx,3) ! Blue
+        image_color(j,i,4) = 255            ! Alpha
     end do
-    print *, "The Mandelbrot image in color:"
-    call show_img_color(j_max, i_max, image_color)
-    print *, "The Mandelbrot image in grayscale:"
-    call show_img(j_max, i_max, image)
-    print *, "Done."
+end do
+print *, "The Mandelbrot image in color:"
+call show_img_color(Ny, Nx, image_color)
+print *, "The Mandelbrot image in grayscale:"
+call show_img(Ny, Nx, image)
+print *, "Done."
 end program mandelbrot
 `;
 

--- a/utils/source_code_examples.js
+++ b/utils/source_code_examples.js
@@ -3,7 +3,7 @@ var src_code_mandel_brot = `program mandelbrot
     integer  , parameter :: rk       = 8
     integer  , parameter :: i_max    =  600
     integer  , parameter :: j_max    =  450
-    integer  , parameter :: n_max    =  100
+    integer  , parameter :: n_max    =  255
     real (rk), parameter :: x_centre = -0.5_rk
     real (rk), parameter :: y_centre =  0.0_rk
     real (rk), parameter :: width    =  4.0_rk
@@ -12,7 +12,7 @@ var src_code_mandel_brot = `program mandelbrot
     real (rk), parameter :: dy_dj    = -height / j_max
     real (rk), parameter :: x_offset = x_centre - 0.5_rk * (i_max + 1) * dx_di
     real (rk), parameter :: y_offset = y_centre - 0.5_rk * (j_max + 1) * dy_dj
-    integer :: image(j_max, i_max, 4)
+    integer :: image(j_max, i_max), image_color(j_max, i_max, 4)
     integer   :: i
     integer   :: j
     integer   :: n
@@ -23,6 +23,11 @@ var src_code_mandel_brot = `program mandelbrot
     real (rk) :: x_sqr
     real (rk) :: y_sqr
     interface
+        subroutine show_img(n, m, A) bind(c)
+        integer, intent(in) :: n, m
+        integer, intent(in) :: A(n,m)
+        end subroutine
+
         subroutine show_img_color(n, m, A) bind(c)
         integer, intent(in) :: n, m
         integer, intent(in) :: A(n,m,4)
@@ -36,31 +41,31 @@ var src_code_mandel_brot = `program mandelbrot
             y = 0.0_rk
             n = 0
             do
-            x_sqr = x ** 2
-            y_sqr = y ** 2
-            if (x_sqr + y_sqr > 4.0_rk) then
-                image(j,i,1) = 255
-                image(j,i,2) = 0
-                image(j,i,3) = 0
-                image(j,i,4) = 255
-                exit
-            end if
-            if (n == n_max) then
-                image(j,i,1) = 0
-                image(j,i,2) = 0
-                image(j,i,3) = 255
-                image(j,i,4) = 255
-                exit
-            end if
-            y = y_0 + 2.0_rk * x * y
-            x = x_0 + x_sqr - y_sqr
-            n = n + 1
+                x_sqr = x ** 2
+                y_sqr = y ** 2
+                if (x_sqr + y_sqr > 4.0_rk .or. n == n_max) then
+                    image(j,i) = 255-n
+                    exit
+                end if
+                y = y_0 + 2.0_rk * x * y
+                x = x_0 + x_sqr - y_sqr
+                n = n + 1
             end do
         end do
     end do
-    print *, "The Mandelbrot image is:"
-    call show_img_color(j_max, i_max, image)
-    print *, "Thank you! Hope you had fun!"
+    do j = 1, j_max
+        do i = 1, i_max
+            image_color(j,i,1) = image(j,i)         ! Red
+            image_color(j,i,2) = image(j,i)         ! Green
+            image_color(j,i,3) = 255-image(j,i)/2   ! Blue
+            image_color(j,i,4) = 255                ! Alpha
+        end do
+    end do
+    print *, "The Mandelbrot image in color:"
+    call show_img_color(j_max, i_max, image_color)
+    print *, "The Mandelbrot image in grayscale:"
+    call show_img(j_max, i_max, image)
+    print *, "Done."
 end program mandelbrot
 `;
 

--- a/utils/source_code_examples.js
+++ b/utils/source_code_examples.js
@@ -12,8 +12,8 @@ var src_code_mandel_brot = `program mandelbrot
     real (rk), parameter :: dy_dj    = -height / j_max
     real (rk), parameter :: x_offset = x_centre - 0.5_rk * (i_max + 1) * dx_di
     real (rk), parameter :: y_offset = y_centre - 0.5_rk * (j_max + 1) * dy_dj
-    integer :: image(j_max, i_max), image_color(j_max, i_max, 4)
-    integer   :: i
+    integer :: image(j_max, i_max), image_color(j_max, i_max, 4), palette(4,3)
+    integer   :: i, idx
     integer   :: j
     integer   :: n
     real (rk) :: x
@@ -53,12 +53,18 @@ var src_code_mandel_brot = `program mandelbrot
             end do
         end do
     end do
+    palette(1,1) =   0; palette(1,2) = 135; palette(1,3) =  68
+    palette(2,1) =   0; palette(2,2) =  87; palette(2,3) = 231
+    palette(3,1) = 214; palette(3,2) =  45; palette(3,3) =  32
+    palette(4,1) = 255; palette(4,2) = 167; palette(4,3) =   0
+
     do j = 1, j_max
         do i = 1, i_max
-            image_color(j,i,1) = image(j,i)         ! Red
-            image_color(j,i,2) = image(j,i)         ! Green
-            image_color(j,i,3) = 255-image(j,i)/2   ! Blue
-            image_color(j,i,4) = 255                ! Alpha
+            idx = image(j,i) - (image(j,i)/4)*4 + 1
+            image_color(j,i,1) = palette(idx,1) ! Red
+            image_color(j,i,2) = palette(idx,2) ! Green
+            image_color(j,i,3) = palette(idx,3) ! Blue
+            image_color(j,i,4) = 255            ! Alpha
         end do
     end do
     print *, "The Mandelbrot image in color:"

--- a/utils/source_code_examples.js
+++ b/utils/source_code_examples.js
@@ -12,7 +12,7 @@ var src_code_mandel_brot = `program mandelbrot
     real (rk), parameter :: dy_dj    = -height / j_max
     real (rk), parameter :: x_offset = x_centre - 0.5_rk * (i_max + 1) * dx_di
     real (rk), parameter :: y_offset = y_centre - 0.5_rk * (j_max + 1) * dy_dj
-    integer :: image(j_max, i_max)
+    integer :: image(j_max, i_max, 4)
     integer   :: i
     integer   :: j
     integer   :: n
@@ -23,9 +23,9 @@ var src_code_mandel_brot = `program mandelbrot
     real (rk) :: x_sqr
     real (rk) :: y_sqr
     interface
-        subroutine show_img(n, m, A) bind(c)
+        subroutine show_img_color(n, m, A) bind(c)
         integer, intent(in) :: n, m
-        integer, intent(in) :: A(n,m)
+        integer, intent(in) :: A(n,m,4)
         end subroutine
     end interface
     do j = 1, j_max
@@ -39,11 +39,17 @@ var src_code_mandel_brot = `program mandelbrot
             x_sqr = x ** 2
             y_sqr = y ** 2
             if (x_sqr + y_sqr > 4.0_rk) then
-                image(j,i) = 255
+                image(j,i,1) = 255
+                image(j,i,2) = 0
+                image(j,i,3) = 0
+                image(j,i,4) = 255
                 exit
             end if
             if (n == n_max) then
-                image(j,i) = 0
+                image(j,i,1) = 0
+                image(j,i,2) = 0
+                image(j,i,3) = 255
+                image(j,i,4) = 255
                 exit
             end if
             y = y_0 + 2.0_rk * x * y
@@ -53,7 +59,7 @@ var src_code_mandel_brot = `program mandelbrot
         end do
     end do
     print *, "The Mandelbrot image is:"
-    call show_img(j_max, i_max, image)
+    call show_img_color(j_max, i_max, image)
     print *, "Thank you! Hope you had fun!"
 end program mandelbrot
 `;


### PR DESCRIPTION
A few things that should be fixed in subsequent PRs:

* The WASM backend indexes multidimensional arrays in row-major order,
  while in Fortran we need column-major order. We currently declare the
  array as `image(j_max,i_max,4)`, but we should declare it as
  `image(4,i_max,j_max)`.
* We should declare the array as `i8`, that is, `integer(1)`, then we do
  not need to skip bytes when copying to the canvas in JavaScript.
* Once we use `i8` we should investigate if there is a faster way to
  update the canvas without an explicit copy
* We should have both demos (grayscale and color)

Fixes #13.