### PR TITLE
Download files from wasm builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,15 +34,12 @@ jobs:
     - name: Build Site
       shell: bash -l {0}
       run: |
-        npm run build
-        npm run export
+        ./build.sh
 
     - name: Misc Steps
       shell: bash -l {0}
       run: |
         mv out deploy
-        touch deploy/.nojekyll
-        echo "dev.lfortran.org" > deploy/CNAME
 
     - name: SSH Setup
       shell: bash -l {0}

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,10 @@
+#!/bin/bash
+
+# curl https://lfortran.github.io/wasm_builds/data.json -o data.json
+latest_commit=`curl https://lfortran.github.io/wasm_builds/latest_commit`
+curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.js" -o public/lfortran.js
+curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.wasm" -o public/lfortran.wasm
+
 npm run build
 npm run export
 echo "dev.lfortran.org" >> out/CNAME

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # curl https://lfortran.github.io/wasm_builds/data.json -o data.json
-latest_commit=`curl https://lfortran.github.io/wasm_builds/latest_commit`
+latest_commit=`curl https://lfortran.github.io/wasm_builds/dev/latest_commit`
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.js" -o public/lfortran.js
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.wasm" -o public/lfortran.wasm
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,0 @@
-git add .
-git commit -m "Deploying"
-git subtree push --prefix out ubaid gh-pages


### PR DESCRIPTION
This `PR` adds support for downloading `lfortran.js` and `lfortran.wasm` files from `wasm_builds`.