### PR TITLE
Increment lfortran latest_commit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -ex
 # curl https://lfortran.github.io/wasm_builds/data.json -o data.json
 #latest_commit=`curl https://lfortran.github.io/wasm_builds/dev/latest_commit`
 # Set a specific commit to use:
-latest_commit="4f6dff456"
+latest_commit="20c0cd549"
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.js" -o public/lfortran.js
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.wasm" -o public/lfortran.wasm
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.data" -o public/lfortran.data


### PR DESCRIPTION
It seems to work on my system. Upgrading the commit (hopefully) brings the support of the runtime library to the live site.

![image](https://user-images.githubusercontent.com/43722035/185996110-f8092a6f-8adf-42a9-930d-cd46a26a29a4.png)
