### PR TITLE
CI: Fix: Use origin as deploy_push url for commits to main

### DIFF
--- a/ci/upload_site.sh
+++ b/ci/upload_site.sh
@@ -11,7 +11,7 @@ eval "$(ssh-agent -s)"
 
 if [[ ${git_ref} == "refs/heads/main" ]]; then
     # Production version - pipeline triggered from main branch
-    deploy_repo_push="git@github.com:lfortran/lcompilers_frontend.git"
+    deploy_repo_push="origin"
 
     D=".."
     cp deploy/ $D/deploy -r


### PR DESCRIPTION
This is another attempt to fix the CI.

Issue developed after merging of https://github.com/lfortran/lcompilers_frontend/pull/38
Previous attempts: https://github.com/lfortran/lcompilers_frontend/pull/41, https://github.com/lfortran/lcompilers_frontend/pull/42