### PR TITLE
Update lfortran commit sha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 
     - name: Create Deployment Comment
-      if: ${{ github.ref != 'refs/heads/main' && secrets.GITHUB_TOKEN != '' }}
+      if: ${{ github.ref != 'refs/heads/main' && github.token != '' }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,8 +52,12 @@ jobs:
       env:
           GIT_PR_PREVIEW_PRIVATE_SSH_KEY: ${{ secrets.GIT_PR_PREVIEW_PRIVATE_SSH_KEY }}
 
+    # At the start of each workflow run, GitHub automatically creates a unique GITHUB_TOKEN
+    # secret to use in your workflow. More details about it can be found at the below link.
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+
     - name: Create Deployment Comment
-      if: ${{ github.ref != 'refs/heads/main' && github.event.pull_request.head.repo.name == github.repository }}
+      if: ${{ github.ref != 'refs/heads/main' && secrets.GITHUB_TOKEN != '' }}
       uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,5 +58,5 @@ jobs:
       with:
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          Your site is deployed at https://preview.dev.lfortran.org/
+          Your site is deployed at https://lfortran.github.io/pull_request_preview
         reactions: 'rocket'

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -ex
 # curl https://lfortran.github.io/wasm_builds/data.json -o data.json
 #latest_commit=`curl https://lfortran.github.io/wasm_builds/dev/latest_commit`
 # Set a specific commit to use:
-latest_commit="ce519bee8"
+latest_commit="e70d2e7d3"
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.js" -o public/lfortran.js
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.wasm" -o public/lfortran.wasm
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.data" -o public/lfortran.data

--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,3 @@ curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.data" -
 npm run build
 npm run export
 echo "dev.lfortran.org" >> out/CNAME
-touch out/.nojekyll

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.js" -o 
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.wasm" -o public/lfortran.wasm
 curl "https://lfortran.github.io/wasm_builds/dev/$latest_commit/lfortran.data" -o public/lfortran.data
 
+export MY_ENV=$([[ ${GITHUB_REF} == "refs/heads/main" ]] && echo "production" || echo "development")
 npm run build
 npm run export
 echo "dev.lfortran.org" >> out/CNAME

--- a/ci/upload_site.sh
+++ b/ci/upload_site.sh
@@ -35,6 +35,7 @@ git fetch origin
 git checkout gh-pages
 rm -rf *
 mv $D/deploy/* .
+touch .nojekyll
 
 git config user.email "noreply@deploy"
 git config user.name "Deploy"

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  basePath: (process.env.NODE_ENV !== "production" ? "" : "")
+  basePath: (process.env.MY_ENV !== "production" ? "/pull_request_preview" : "")
 }
 
 module.exports = nextConfig

--- a/utils/source_code_examples.js
+++ b/utils/source_code_examples.js
@@ -1,5 +1,5 @@
 var src_code_mandel_brot = `program mandelbrot
-integer, parameter :: Nx = 600, Ny = 450, n_max = 255, dp=8
+integer, parameter :: Nx = 600, Ny = 450, n_max = 255, dp=kind(0.d0)
 real(dp), parameter :: xcenter = -0.5_dp, ycenter = 0.0_dp, &
     width = 4, height = 3, dx_di = width/Nx, dy_dj = -height/Ny, &
     x_offset = xcenter - (Nx+1)*dx_di/2, y_offset = ycenter - (Ny+1)*dy_dj/2


### PR DESCRIPTION
This `PR` updates the `latest_commit` to current available latest_commit at https://github.com/lfortran/wasm_builds/blob/main/docs/dev/latest_commit. 

Since, this is the first time we are trying the `pull_request_preview` feature, this `PR` also fixes some of the issues discovered, related to the `CI` and/or `pull_request_preview` feature. 

PS: This `PR` is related to or in continuation of https://github.com/lfortran/lcompilers_frontend/pull/38.