### PR TITLE
Added links to repository and issues section

### DIFF
--- a/components/MyFooter.js
+++ b/components/MyFooter.js
@@ -13,9 +13,9 @@ function MyFooter() {
             }}
         >
             <a href="https://lfortran.org/">LFortran</a> (<a href={"https://github.com/lfortran/lfortran/commit/" + commit.id}>{commit.id}</a>) by &nbsp;
-+            <a href="https://lcompilers.org/">LCompilers</a> | &nbsp;
-+            <a href="https://github.com/lfortran/lcompilers_frontend">Contribute</a> |&nbsp;
-+            <a href="https://github.com/lfortran/lcompilers_frontend/issues">Report Issues</a>
+            <a href="https://lcompilers.org/">LCompilers</a> | &nbsp;
+            <a href="https://github.com/lfortran/lcompilers_frontend">Contribute</a> |&nbsp;
+            <a href="https://github.com/lfortran/lcompilers_frontend/issues">Report Issues</a>
         </Footer>
     );
 }

--- a/components/MyFooter.js
+++ b/components/MyFooter.js
@@ -12,7 +12,10 @@ function MyFooter() {
                 width: "100%",
             }}
         >
-            <a href="https://lfortran.org/">LFortran</a> (<a href={"https://github.com/lfortran/lfortran/commit/" + commit.id}>{commit.id}</a>) by <a href="https://lcompilers.org/">LCompilers</a>
+            <a href="https://lfortran.org/">LFortran</a> (<a href={"https://github.com/lfortran/lfortran/commit/" + commit.id}>{commit.id}</a>) by 
+            <a href="https://lcompilers.org/">LCompilers</a> 
+            <a href="https://github.com/lfortran/lcompilers_frontend">Contribute</a>
+            <a href="https://github.com/lfortran/lcompilers_frontend/issues">Report Issues</a>
         </Footer>
     );
 }

--- a/components/MyFooter.js
+++ b/components/MyFooter.js
@@ -12,10 +12,10 @@ function MyFooter() {
                 width: "100%",
             }}
         >
-            <a href="https://lfortran.org/">LFortran</a> (<a href={"https://github.com/lfortran/lfortran/commit/" + commit.id}>{commit.id}</a>) by 
-            <a href="https://lcompilers.org/">LCompilers</a> 
-            <a href="https://github.com/lfortran/lcompilers_frontend">Contribute</a>
-            <a href="https://github.com/lfortran/lcompilers_frontend/issues">Report Issues</a>
+            <a href="https://lfortran.org/">LFortran</a> (<a href={"https://github.com/lfortran/lfortran/commit/" + commit.id}>{commit.id}</a>) by &nbsp;
++            <a href="https://lcompilers.org/">LCompilers</a> | &nbsp;
++            <a href="https://github.com/lfortran/lcompilers_frontend">Contribute</a> |&nbsp;
++            <a href="https://github.com/lfortran/lcompilers_frontend/issues">Report Issues</a>
         </Footer>
     );
 }


### PR DESCRIPTION
Fix: https://github.com/lfortran/lcompilers_frontend/issues/6
Added links in the footer to direct to the main repository and issues section for contribution and raising issues. 