### PR TITLE
Remove unused portion from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
-
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
-
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
This api routes folder was removed in https://github.com/lfortran/lcompilers_frontend/pull/65.

Also, towards https://github.com/lfortran/lcompilers_frontend/issues/7.