### PR TITLE
add: functionality to add code from url and github gists

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -51,26 +51,46 @@ export default function Home() {
 
     useEffect(() => {
         const url = window.location.search;
-        const gist = 'https://gist.githubusercontent.com/';
+        const gist = "https://gist.githubusercontent.com/";
         const urlParams = new URLSearchParams(url);
-        if(urlParams.get('code')){
-        setSourceCode(decodeURIComponent(urlParams.get('code')));
+      
+        if (urlParams.get("code")) {
+          setSourceCode(decodeURIComponent(urlParams.get("code")));
+          openNotification(
+            `${activeTab} Source Code loaded from url.`,
+            "bottomRight"
+          );
+          handleUserTabChange("STDOUT");
+        } else if (urlParams.get("gist")) {
+          const gistUrl = gist + urlParams.get("gist") + "/raw/";
+          fetch(gistUrl)
+            .then((response) => response.text())
+            .then((data) => {
+              setSourceCode(data);
+              openNotification(
+                `${activeTab} Source Code loaded from gist.`,
+                "bottomRight"
+              );
+              handleUserTabChange("STDOUT");
+            })
+            .then((d) => {
+              handleUserTabChange(activeTab);
+            })
+            .catch((error) => {
+              console.error("Error fetching data:", error);
+              openNotification(`${activeTab} error fetching.`, "bottomRight");
+            });
+        } else {
+          openNotification(
+            `${activeTab} Unknown parameter Supplied, loading default code.`,
+            "bottomRight"
+          );
+          setSourceCode(preinstalled_programs.basic.mandelbrot);
+          handleUserTabChange(activeTab);
         }
+      }, []);
 
-        if(urlParams.get('github')){
-            const gistUrl = gist+urlParams.get('github')+ '/raw/';
-            fetch(gistUrl)
-            .then(response => response.text())
-            .then(data => {
-        console.log(data);
-        setSourceCode(data);
-      })
-      .catch(error => {
-        console.error('Error fetching data:', error);
-      });
-        }
-    }, []);
-
+      
     async function handleUserTabChange(key) {
         if (key == "STDOUT") {
             if(sourceCode.trim() === ""){

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,18 +50,18 @@ export default function Home() {
     const myHeight = ((!isMobile) ? "calc(100vh - 170px)" : "calc(50vh - 85px)");
 
     useEffect(() => {
-           fetchData(); 
+           fetchData();
       }, []);
 
       useEffect(() => {
             if(moduleReady){handleUserTabChange("STDOUT"); }
-  }, []);
+    }, [moduleReady]);
 
     async function fetchData() {
         const url = window.location.search;
         const gist = "https://gist.githubusercontent.com/";
         const urlParams = new URLSearchParams(url);
-      
+
         if (urlParams.get("code")) {
             setSourceCode(decodeURIComponent(urlParams.get("code")));
         } else if (urlParams.get("gist")) {
@@ -74,15 +74,14 @@ export default function Home() {
                     "Source Code loaded from gist.",
                     "bottomRight"
                 );
-                
+
                 })
                 .catch((error) => {
                     console.error("Error fetching data:", error);
                     openNotification("error fetching .", "bottomRight");
                 });
         }
-         } 
-            
+    }
 
     async function handleUserTabChange(key) {
         if (key == "STDOUT") {

--- a/pages/index.js
+++ b/pages/index.js
@@ -54,7 +54,7 @@ export default function Home() {
         const gist = 'https://gist.githubusercontent.com/';
         const urlParams = new URLSearchParams(url);
         if(urlParams.get('code')){
-        setSourceCode(atob(urlParams.get('code')));
+        setSourceCode(decodeURIComponent(urlParams.get('code')));
         }
 
         if(urlParams.get('github')){

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,7 +4,7 @@ import LoadLFortran from "../components/LoadLFortran";
 import preinstalled_programs from "../utils/preinstalled_programs";
 import { useIsMobile } from "../components/useIsMobile";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Col, Row, Spin } from "antd";
 import { notification } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
@@ -48,6 +48,28 @@ export default function Home() {
     const isMobile = useIsMobile();
 
     const myHeight = ((!isMobile) ? "calc(100vh - 170px)" : "calc(50vh - 85px)");
+
+    useEffect(() => {
+        const url = window.location.search;
+        const gist = 'https://gist.githubusercontent.com/';
+        const urlParams = new URLSearchParams(url);
+        if(urlParams.get('code')){
+        setSourceCode(urlParams.get('code'));
+        }
+
+        if(urlParams.get('github')){
+            const gistUrl = gist+urlParams.get('github')+ '/raw/';
+            fetch(gistUrl)
+            .then(response => response.text())
+            .then(data => {
+        console.log(data);
+        setSourceCode(data);
+      })
+      .catch(error => {
+        console.error('Error fetching data:', error);
+      });
+        }
+    }, []);
 
     async function handleUserTabChange(key) {
         if (key == "STDOUT") {

--- a/pages/index.js
+++ b/pages/index.js
@@ -54,7 +54,7 @@ export default function Home() {
         const gist = 'https://gist.githubusercontent.com/';
         const urlParams = new URLSearchParams(url);
         if(urlParams.get('code')){
-        setSourceCode(urlParams.get('code'));
+        setSourceCode(atob(urlParams.get('code')));
         }
 
         if(urlParams.get('github')){

--- a/pages/index.js
+++ b/pages/index.js
@@ -79,12 +79,8 @@ export default function Home() {
                 .catch((error) => {
                     console.error("Error fetching data:", error);
                     openNotification("error fetching .", "bottomRight");
-                    setSourceCode(preinstalled_programs.basic.mandelbrot);
                 });
         }
-         else {
-             setSourceCode(preinstalled_programs.basic.mandelbrot);
-            }
          } 
             
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,17 +50,17 @@ export default function Home() {
     const myHeight = ((!isMobile) ? "calc(100vh - 170px)" : "calc(50vh - 85px)");
 
     useEffect(() => {
+        if(moduleReady) { fetchData();  handleUserTabChange("STDOUT"); }
+      }, [moduleReady]);
+
+    async function fetchData() {
         const url = window.location.search;
         const gist = "https://gist.githubusercontent.com/";
         const urlParams = new URLSearchParams(url);
       
         if (urlParams.get("code")) {
           setSourceCode(decodeURIComponent(urlParams.get("code")));
-          openNotification(
-            `${activeTab} Source Code loaded from url.`,
-            "bottomRight"
-          );
-          handleUserTabChange("STDOUT");
+          openNotification( "Source Code loaded from url.", "bottomRight"); 
         } else if (urlParams.get("gist")) {
           const gistUrl = gist + urlParams.get("gist") + "/raw/";
           fetch(gistUrl)
@@ -68,29 +68,24 @@ export default function Home() {
             .then((data) => {
               setSourceCode(data);
               openNotification(
-                `${activeTab} Source Code loaded from gist.`,
+                "Source Code loaded from gist.",
                 "bottomRight"
               );
-              handleUserTabChange("STDOUT");
-            })
-            .then((d) => {
-              handleUserTabChange(activeTab);
+              
             })
             .catch((error) => {
               console.error("Error fetching data:", error);
-              openNotification(`${activeTab} error fetching.`, "bottomRight");
+            //   openNotification("error fetching .", "bottomRight");
+            setSourceCode(preinstalled_programs.basic.mandelbrot);
             });
-        } else {
-          openNotification(
-            `${activeTab} Unknown parameter Supplied, loading default code.`,
-            "bottomRight"
-          );
-          setSourceCode(preinstalled_programs.basic.mandelbrot);
-          handleUserTabChange(activeTab);
         }
-      }, []);
+         else {
+          openNotification("Unknown parameter Supplied, loading default code.","bottomRight");
+          setSourceCode(preinstalled_programs.basic.mandelbrot);
+            }
+         } 
+            
 
-      
     async function handleUserTabChange(key) {
         if (key == "STDOUT") {
             if(sourceCode.trim() === ""){

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,8 +50,8 @@ export default function Home() {
     const myHeight = ((!isMobile) ? "calc(100vh - 170px)" : "calc(50vh - 85px)");
 
     useEffect(() => {
-            if(moduleReady) { fetchData(); }
-      }, [moduleReady]);
+           fetchData(); 
+      }, []);
 
       useEffect(() => {
             if(moduleReady){handleUserTabChange("STDOUT"); }

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,8 +50,12 @@ export default function Home() {
     const myHeight = ((!isMobile) ? "calc(100vh - 170px)" : "calc(50vh - 85px)");
 
     useEffect(() => {
-        if(moduleReady) { fetchData();  handleUserTabChange("STDOUT"); }
+            if(moduleReady) { fetchData(); }
       }, [moduleReady]);
+
+      useEffect(() => {
+            if(moduleReady){handleUserTabChange("STDOUT"); }
+  }, []);
 
     async function fetchData() {
         const url = window.location.search;
@@ -59,29 +63,27 @@ export default function Home() {
         const urlParams = new URLSearchParams(url);
       
         if (urlParams.get("code")) {
-          setSourceCode(decodeURIComponent(urlParams.get("code")));
-          openNotification( "Source Code loaded from url.", "bottomRight"); 
+            setSourceCode(decodeURIComponent(urlParams.get("code")));
         } else if (urlParams.get("gist")) {
-          const gistUrl = gist + urlParams.get("gist") + "/raw/";
-          fetch(gistUrl)
-            .then((response) => response.text())
-            .then((data) => {
-              setSourceCode(data);
-              openNotification(
-                "Source Code loaded from gist.",
-                "bottomRight"
-              );
-              
-            })
-            .catch((error) => {
-              console.error("Error fetching data:", error);
-            //   openNotification("error fetching .", "bottomRight");
-            setSourceCode(preinstalled_programs.basic.mandelbrot);
-            });
+            const gistUrl = gist + urlParams.get("gist") + "/raw/";
+            fetch(gistUrl)
+                .then((response) => response.text())
+                .then((data) => {
+                setSourceCode(data);
+                openNotification(
+                    "Source Code loaded from gist.",
+                    "bottomRight"
+                );
+                
+                })
+                .catch((error) => {
+                    console.error("Error fetching data:", error);
+                    openNotification("error fetching .", "bottomRight");
+                    setSourceCode(preinstalled_programs.basic.mandelbrot);
+                });
         }
          else {
-          openNotification("Unknown parameter Supplied, loading default code.","bottomRight");
-          setSourceCode(preinstalled_programs.basic.mandelbrot);
+             setSourceCode(preinstalled_programs.basic.mandelbrot);
             }
          } 
             


### PR DESCRIPTION
Implments #78 #81 functionality to directly add code from a url or a github gist into the frontend.

proposed functionality:

To support github gists
`
http://localhost:3000/?github=certik/b6d162bee7fdd7711722221a90729a2a
`

To support code in url (similar to fortran playground) 
**code must be URI encoded to retain the format of the code.**

`
http://localhost:3000/?code=program%20hello%0A%20%20!%20This%20is%20a%20comment%20line%3B%20it%20is%20ignored%20by%20the%20compiler%0A%20%20print%20*%2C%20'Hello%2C%20World!'%0Aend%20program%20hello%0A
`

Thanks and Regards,
Henil Panchal

CC: @certik @Shaikh-Ubaid